### PR TITLE
Fixing RPCs broken by dropping json-rpc support

### DIFF
--- a/lib/gapi.d.ts
+++ b/lib/gapi.d.ts
@@ -7,10 +7,17 @@ interface GapiClientRequest {
   execute(callBack:(Object)=>void):void;
 }
 
+interface GapiHttpBatch {
+  add(req:GapiClientRequest, opt?:Object);
+  execute();
+}
+
 interface GapiClient {
   setApiKey(key:string);
   request(p:GapiClientRequestParams):GapiClientRequest;
   load(api:string, version:string, onSetup:()=>void);
+  register(method:Object);
+  newHttpBatch():GapiHttpBatch;
 }
 
 module gapi {

--- a/lib/suggest/jquery.freebase.minitopic.js
+++ b/lib/suggest/jquery.freebase.minitopic.js
@@ -253,7 +253,7 @@
       var image_id = images[0].id;
       var image_title = images[0].name || 'Image of ???'; //TODO: use topic name
       h[h.length]='<div class="fbase-mt-imgframe">';
-      h[h.length]='<img src="' + freebase.imageUrl(image_id, {maxwidth:100, maxheight:5000}) + '" alt="'+image_title+'" title="'+image_title+'" border="0" class="fbase-mt-img" />';
+      h[h.length]='<img src="' + freebase.imageUrl(image_id, {maxwidth:100, maxheight:4096}) + '" alt="'+image_title+'" title="'+image_title+'" border="0" class="fbase-mt-img" />';
       h[h.length]='</div>';
   }
   // else ??

--- a/src/output.ts
+++ b/src/output.ts
@@ -178,10 +178,10 @@ function getSFTriples(entities, assertNakedProperties,
       triple.value
     }
     return {
-        sub: triple.s,
-        pred: triple.p,
+        sub: triple.sub,
+        pred: triple.pred,
         obj: obj,
-        obj_type: getObjType(triple.p)
+        obj_type: getObjType(triple.pred)
     }
   }
 


### PR DESCRIPTION
This fixes the raw-ish reconcile RPC by replacing the JSON-RPC call with the supported alternative, HttpBatch.

Also fixed:
- image preview: we were asking for an image of size 5000 when the max is 4096.
- output.ts: pred/sub vs. p/s. No idea why this wasn't working, or if this is the right thing, but it doesn't throw an error now.
